### PR TITLE
Updates Dockerfiles to standardize FROM/AS casing

### DIFF
--- a/default/Dockerfile
+++ b/default/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:20-alpine as development-dependencies-env
+FROM node:20-alpine AS development-dependencies-env
 COPY . /app
 WORKDIR /app
 RUN npm ci
 
-FROM node:20-alpine as production-dependencies-env
+FROM node:20-alpine AS production-dependencies-env
 COPY ./package.json package-lock.json /app/
 WORKDIR /app
 RUN npm ci --omit=dev

--- a/default/Dockerfile.bun
+++ b/default/Dockerfile.bun
@@ -1,12 +1,12 @@
-FROM oven/bun:1 as dependencies-env
+FROM oven/bun:1 AS dependencies-env
 COPY . /app
 
-FROM dependencies-env as development-dependencies-env
+FROM dependencies-env AS development-dependencies-env
 COPY ./package.json bun.lockb /app/
 WORKDIR /app
 RUN bun i --frozen-lockfile
 
-FROM dependencies-env as production-dependencies-env
+FROM dependencies-env AS production-dependencies-env
 COPY ./package.json bun.lockb /app/
 WORKDIR /app
 RUN bun i --production

--- a/default/Dockerfile.pnpm
+++ b/default/Dockerfile.pnpm
@@ -1,13 +1,13 @@
-FROM node:20-alpine as dependencies-env
+FROM node:20-alpine AS dependencies-env
 RUN npm i -g pnpm
 COPY . /app
 
-FROM dependencies-env as development-dependencies-env
+FROM dependencies-env AS development-dependencies-env
 COPY ./package.json pnpm-lock.yaml /app/
 WORKDIR /app
 RUN pnpm i --frozen-lockfile
 
-FROM dependencies-env as production-dependencies-env
+FROM dependencies-env AS production-dependencies-env
 COPY ./package.json pnpm-lock.yaml /app/
 WORKDIR /app
 RUN pnpm i --prod --frozen-lockfile

--- a/node-custom-server/Dockerfile
+++ b/node-custom-server/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:20-alpine as development-dependencies-env
+FROM node:20-alpine AS development-dependencies-env
 COPY . /app
 WORKDIR /app
 RUN npm ci
 
-FROM node:20-alpine as production-dependencies-env
+FROM node:20-alpine AS production-dependencies-env
 COPY ./package.json package-lock.json /app/
 WORKDIR /app
 RUN npm ci --omit=dev

--- a/node-custom-server/Dockerfile.bun
+++ b/node-custom-server/Dockerfile.bun
@@ -1,12 +1,12 @@
-FROM oven/bun:1 as dependencies-env
+FROM oven/bun:1 AS dependencies-env
 COPY . /app
 
-FROM dependencies-env as development-dependencies-env
+FROM dependencies-env AS development-dependencies-env
 COPY ./package.json bun.lockb /app/
 WORKDIR /app
 RUN bun i --frozen-lockfile
 
-FROM dependencies-env as production-dependencies-env
+FROM dependencies-env AS production-dependencies-env
 COPY ./package.json bun.lockb /app/
 WORKDIR /app
 RUN bun i --production

--- a/node-custom-server/Dockerfile.pnpm
+++ b/node-custom-server/Dockerfile.pnpm
@@ -1,13 +1,13 @@
-FROM node:20-alpine as dependencies-env
+FROM node:20-alpine AS dependencies-env
 RUN npm i -g pnpm
 COPY . /app
 
-FROM dependencies-env as development-dependencies-env
+FROM dependencies-env AS development-dependencies-env
 COPY ./package.json pnpm-lock.yaml /app/
 WORKDIR /app
 RUN pnpm i --frozen-lockfile
 
-FROM dependencies-env as production-dependencies-env
+FROM dependencies-env AS production-dependencies-env
 COPY ./package.json pnpm-lock.yaml /app/
 WORKDIR /app
 RUN pnpm i --prod --frozen-lockfile

--- a/node-postgres/Dockerfile
+++ b/node-postgres/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:20-alpine as development-dependencies-env
+FROM node:20-alpine AS development-dependencies-env
 COPY . /app
 WORKDIR /app
 RUN npm ci
 
-FROM node:20-alpine as production-dependencies-env
+FROM node:20-alpine AS production-dependencies-env
 COPY ./package.json package-lock.json /app/
 WORKDIR /app
 RUN npm ci --omit=dev

--- a/node-postgres/Dockerfile.bun
+++ b/node-postgres/Dockerfile.bun
@@ -1,12 +1,12 @@
-FROM oven/bun:1 as dependencies-env
+FROM oven/bun:1 AS dependencies-env
 COPY . /app
 
-FROM dependencies-env as development-dependencies-env
+FROM dependencies-env AS development-dependencies-env
 COPY ./package.json bun.lockb /app/
 WORKDIR /app
 RUN bun i --frozen-lockfile
 
-FROM dependencies-env as production-dependencies-env
+FROM dependencies-env AS production-dependencies-env
 COPY ./package.json bun.lockb /app/
 WORKDIR /app
 RUN bun i --production

--- a/node-postgres/Dockerfile.pnpm
+++ b/node-postgres/Dockerfile.pnpm
@@ -1,13 +1,13 @@
-FROM node:20-alpine as dependencies-env
+FROM node:20-alpine AS dependencies-env
 RUN npm i -g pnpm
 COPY . /app
 
-FROM dependencies-env as development-dependencies-env
+FROM dependencies-env AS development-dependencies-env
 COPY ./package.json pnpm-lock.yaml /app/
 WORKDIR /app
 RUN pnpm i --frozen-lockfile
 
-FROM dependencies-env as production-dependencies-env
+FROM dependencies-env AS production-dependencies-env
 COPY ./package.json pnpm-lock.yaml /app/
 WORKDIR /app
 RUN pnpm i --prod --frozen-lockfile


### PR DESCRIPTION
Running Docker builds produces casing-related warnings due to inconsistent casing between 'FROM' and 'as' keywords. 
 For example:
 - `FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)`
 - `FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 6)`

This PR standardizes all syntax to use uppercase 'AS' to match 'FROM', following [Docker's recommendation for consistent casing](https://docs.docker.com/reference/build-checks/from-as-casing/).
- Before: `FROM node:20-alpine as development-dependencies-env`
- After: `FROM node:20-alpine AS development-dependencies-env`

These changes are purely stylistic, with no functional impact beyond removing the warning.
