### PR TITLE
Fix timeouts on vercel

### DIFF
--- a/vercel/vercel/output/functions/index.func/.vc-config.json
+++ b/vercel/vercel/output/functions/index.func/.vc-config.json
@@ -1,6 +1,5 @@
 {
   "runtime": "nodejs20.x",
   "handler": "index.js",
-  "launcherType": "Nodejs",
-  "shouldAddHelpers": true
+  "launcherType": "Nodejs"
 }


### PR DESCRIPTION
Removed `shouldAddHelpers` to resolve timeouts during POST API requests.

Before: https://react-router-7s63xvh29-lazuee.vercel.app/
After: http://react-router.lazuee.vercel.app/ < https://github.com/lazuee/react-router/commit/78158ba949d0598e8f70a774560a511d8b707e6d
