### PR TITLE
directly call getport in tests

### DIFF
--- a/.tests/test.cloudflare-d1.ts
+++ b/.tests/test.cloudflare-d1.ts
@@ -1,4 +1,6 @@
 import { expect, Page } from "@playwright/test";
+import getPort from "get-port";
+
 import { matchLine, testTemplate, urlRegex } from "./utils.js";
 
 const test = testTemplate("cloudflare-d1");
@@ -7,17 +9,25 @@ test("typecheck", async ({ $ }) => {
   await $(`pnpm typecheck`);
 });
 
-test("dev", async ({ page, port, $ }) => {
+test("dev", async ({ page, $ }) => {
   await $(`pnpm db:migrate`);
+
+  const port = await getPort();
   const dev = $(`pnpm dev --port ${port}`);
+
   const url = await matchLine(dev.stdout, urlRegex.viteDev);
   await workflow({ page, url });
 });
 
-test("build + start", async ({ page, port, $ }) => {
+test("build + start", async ({ page, $ }) => {
   await $(`pnpm db:migrate`);
+
   await $(`pnpm build`);
-  const start = $(`pnpm start --port ${port}`);
+
+  const port1 = await getPort();
+  const port2 = await getPort();
+  const start = $(`pnpm start --port ${port1} --inspector-port ${port2}`);
+
   const url = await matchLine(start.stdout, urlRegex.wrangler);
   await workflow({ page, url });
 });

--- a/.tests/test.cloudflare.ts
+++ b/.tests/test.cloudflare.ts
@@ -1,4 +1,5 @@
 import { expect, Page } from "@playwright/test";
+import getPort from "get-port";
 
 import { matchLine, testTemplate, urlRegex } from "./utils";
 
@@ -8,15 +9,21 @@ test("typecheck", async ({ $ }) => {
   await $(`pnpm typecheck`);
 });
 
-test("dev", async ({ page, port, $ }) => {
+test("dev", async ({ page, $ }) => {
+  const port = await getPort();
   const dev = $(`pnpm dev --port ${port}`);
+
   const url = await matchLine(dev.stdout, urlRegex.viteDev);
   await workflow({ page, url });
 });
 
-test("build + start", async ({ page, port, $ }) => {
+test("build + start", async ({ page, $ }) => {
   await $(`pnpm build`);
-  const start = $(`pnpm start --port ${port}`);
+
+  const port1 = await getPort();
+  const port2 = await getPort();
+  const start = $(`pnpm start --port ${port1} --inspector-port ${port2}`);
+
   const url = await matchLine(start.stdout, urlRegex.wrangler);
   await workflow({ page, url });
 });

--- a/.tests/test.default.ts
+++ b/.tests/test.default.ts
@@ -1,4 +1,5 @@
 import { expect, Page } from "@playwright/test";
+import getPort from "get-port";
 
 import { matchLine, testTemplate, urlRegex } from "./utils";
 
@@ -8,15 +9,20 @@ test("typecheck", async ({ $ }) => {
   await $(`pnpm typecheck`);
 });
 
-test("dev", async ({ page, port, $ }) => {
+test("dev", async ({ page, $ }) => {
+  const port = await getPort();
   const dev = $(`pnpm dev --port ${port}`);
+
   const url = await matchLine(dev.stdout, urlRegex.viteDev);
   await workflow({ page, url });
 });
 
-test("build + start", async ({ page, port, $ }) => {
+test("build + start", async ({ page, $ }) => {
   await $(`pnpm build`);
+
+  const port = await getPort();
   const start = $(`pnpm start`, { env: { PORT: String(port) } });
+
   const url = await matchLine(start.stdout, urlRegex.reactRouterServe);
   await workflow({ page, url });
 });

--- a/.tests/test.netlify.ts
+++ b/.tests/test.netlify.ts
@@ -1,4 +1,5 @@
 import { expect, Page } from "@playwright/test";
+import getPort from "get-port";
 
 import { matchLine, testTemplate, urlRegex } from "./utils";
 
@@ -8,19 +9,28 @@ test("typecheck", async ({ $ }) => {
   await $(`pnpm typecheck`);
 });
 
-test("dev", async ({ page, port, $ }) => {
+test("dev", async ({ page, $ }) => {
+  const port = await getPort();
   const dev = $(`pnpm dev`, { env: { PORT: String(port) } });
+
   const url = await matchLine(dev.stdout, urlRegex.custom);
   await workflow({ page, url });
 });
 
-test("build + start", async ({ page, edit, port, $ }) => {
+test("build + start", async ({ page, edit, $ }) => {
   await edit("netlify.toml", (txt) =>
     txt
       .replaceAll("[dev]", "[dev]\nautoLaunch = false")
       .replaceAll("npm run", "pnpm")
   );
-  const start = $(`pnpm start --port ${port}`);
+
+  const port1 = await getPort();
+  const port2 = await getPort();
+  const port3 = await getPort();
+  const start = $(
+    `pnpm start --port ${port1} --functionsPort ${port2} --staticServerPort ${port3}`
+  );
+
   const url = await matchLine(start.stdout, urlRegex.netlify);
   await workflow({ page, url });
 });

--- a/.tests/test.node-custom-server.ts
+++ b/.tests/test.node-custom-server.ts
@@ -1,4 +1,5 @@
 import { expect, Page } from "@playwright/test";
+import getPort from "get-port";
 
 import { matchLine, testTemplate, urlRegex } from "./utils";
 
@@ -8,15 +9,20 @@ test("typecheck", async ({ $ }) => {
   await $(`pnpm typecheck`);
 });
 
-test("dev", async ({ page, port, $ }) => {
+test("dev", async ({ page, $ }) => {
+  const port = await getPort();
   const dev = $(`pnpm dev`, { env: { PORT: String(port) } });
+
   const url = await matchLine(dev.stdout, urlRegex.custom);
   await workflow({ page, url });
 });
 
-test("build + start", async ({ page, port, $ }) => {
+test("build + start", async ({ page, $ }) => {
   await $(`pnpm build`);
+
+  const port = await getPort();
   const start = $(`pnpm start`, { env: { PORT: String(port) } });
+
   const url = await matchLine(start.stdout, urlRegex.custom);
   await workflow({ page, url });
 });

--- a/.tests/test.vercel.ts
+++ b/.tests/test.vercel.ts
@@ -1,4 +1,5 @@
 import { expect, Page } from "@playwright/test";
+import getPort from "get-port";
 
 import { matchLine, testTemplate, urlRegex } from "./utils";
 
@@ -8,8 +9,10 @@ test("typecheck", async ({ $ }) => {
   await $(`pnpm typecheck`);
 });
 
-test("dev", async ({ page, port, $ }) => {
+test("dev", async ({ page, $ }) => {
+  const port = await getPort();
   const dev = $(`pnpm dev`, { env: { PORT: String(port) } });
+
   const url = await matchLine(dev.stdout, urlRegex.custom);
   await workflow({ page, url });
 });

--- a/.tests/utils.ts
+++ b/.tests/utils.ts
@@ -10,7 +10,6 @@ import {
   ResultPromise,
 } from "execa";
 import fs from "fs-extra";
-import getPort from "get-port";
 import * as Path from "pathe";
 import { Readable } from "stream";
 import { ChildProcess } from "child_process";
@@ -40,7 +39,6 @@ export const testTemplate = (template: string) =>
   playwrightTest.extend<{
     cwd: string;
     edit: Edit;
-    port: number;
     $: Command;
   }>({
     page: async ({ page }, use) => {
@@ -76,10 +74,6 @@ export const testTemplate = (template: string) =>
         let contents = fs.readFileSync(filepath, "utf8");
         return fs.writeFileSync(filepath, transform(contents), "utf8");
       });
-    },
-    port: async ({}, use) => {
-      const port = await getPort();
-      await use(port);
     },
     $: async ({ cwd }, use) => {
       const spawn = execa({


### PR DESCRIPTION
instead of providing `port` as a fixture
since it doesn't need lifecycle and doesn't depend on other fixtures