### PR TITLE
fix(typescript): process referenced projects in typecheck script

### DIFF
--- a/cloudflare-d1/.gitignore
+++ b/cloudflare-d1/.gitignore
@@ -8,3 +8,6 @@
 # Cloudflare
 .mf
 .wrangler
+
+# TypeScript incremental compilation cache
+*.tsbuildinfo

--- a/cloudflare-d1/.gitignore
+++ b/cloudflare-d1/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /node_modules/
+*.tsbuildinfo
 
 # React Router
 /.react-router/
@@ -8,6 +9,3 @@
 # Cloudflare
 .mf
 .wrangler
-
-# TypeScript incremental compilation cache
-*.tsbuildinfo

--- a/cloudflare-d1/package.json
+++ b/cloudflare-d1/package.json
@@ -8,7 +8,7 @@
     "db:migrate-production": "dotenv -- drizzle-kit migrate",
     "dev": "react-router dev",
     "start": "wrangler dev",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc -b"
   },
   "dependencies": {
     "@react-router/node": "*",

--- a/cloudflare/.gitignore
+++ b/cloudflare/.gitignore
@@ -8,3 +8,6 @@
 # Cloudflare
 .mf
 .wrangler
+
+# TypeScript incremental compilation cache
+*.tsbuildinfo

--- a/cloudflare/.gitignore
+++ b/cloudflare/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /node_modules/
+*.tsbuildinfo
 
 # React Router
 /.react-router/
@@ -8,6 +9,3 @@
 # Cloudflare
 .mf
 .wrangler
-
-# TypeScript incremental compilation cache
-*.tsbuildinfo

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -5,7 +5,7 @@
     "build": "react-router build",
     "dev": "react-router dev",
     "start": "wrangler dev",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc -b"
   },
   "dependencies": {
     "@react-router/node": "*",

--- a/node-custom-server/.gitignore
+++ b/node-custom-server/.gitignore
@@ -4,3 +4,6 @@
 # React Router
 /.react-router/
 /build/
+
+# TypeScript incremental compilation cache
+*.tsbuildinfo

--- a/node-custom-server/.gitignore
+++ b/node-custom-server/.gitignore
@@ -1,9 +1,7 @@
 .DS_Store
 /node_modules/
+*.tsbuildinfo
 
 # React Router
 /.react-router/
 /build/
-
-# TypeScript incremental compilation cache
-*.tsbuildinfo

--- a/node-custom-server/package.json
+++ b/node-custom-server/package.json
@@ -5,7 +5,7 @@
     "build": "react-router build",
     "dev": "cross-env NODE_ENV=development node server.js",
     "start": "node server.js",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc -b"
   },
   "dependencies": {
     "@react-router/express": "*",

--- a/node-postgres/.gitignore
+++ b/node-postgres/.gitignore
@@ -5,3 +5,6 @@
 # React Router
 /.react-router/
 /build/
+
+# TypeScript incremental compilation cache
+*.tsbuildinfo

--- a/node-postgres/.gitignore
+++ b/node-postgres/.gitignore
@@ -1,10 +1,8 @@
 .DS_Store
 .env
 /node_modules/
+*.tsbuildinfo
 
 # React Router
 /.react-router/
 /build/
-
-# TypeScript incremental compilation cache
-*.tsbuildinfo

--- a/node-postgres/package.json
+++ b/node-postgres/package.json
@@ -7,7 +7,7 @@
     "db:migrate": "dotenv -- drizzle-kit migrate",
     "dev": "dotenv -- node server.js",
     "start": "node server.js",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc -b"
   },
   "dependencies": {
     "@react-router/express": "*",


### PR DESCRIPTION
When we run `tsc` without the `-b` flag, it skips over referenced projects. This means that every time we run `npm run typecheck`, TypeScript won’t catch errors in those referenced projects. By adding the `-b` flag, we ensure all referenced projects are included, so `tsc` can properly check everything and catch any errors.

---

This pull request includes updates to `.gitignore` and `package.json` files across multiple directories to improve TypeScript incremental compilation and cache management.

### Updates to `.gitignore` files:
* Added TypeScript incremental compilation cache (`*.tsbuildinfo`) to `.gitignore` in `cloudflare-d1`, `cloudflare`, `node-custom-server`, and `node-postgres`. [[1]](diffhunk://#diff-b67504416eaa126e1c272ee08dcf562773f7907aab826c366e1aa383a6797cefR11-R13) [[2]](diffhunk://#diff-b67504416eaa126e1c272ee08dcf562773f7907aab826c366e1aa383a6797cefR11-R13) [[3]](diffhunk://#diff-25070b6b08ba11859c14ec1a8e3ed2a9fc88a2be4adf606a17e9e60284aeb9f7R7-R9) [[4]](diffhunk://#diff-c4c8a44b890e7b4122532fddaac443d36706c68be64ea07f236cd6ccbf1036c1R8-R10)

### Updates to `package.json` files:
* Modified the `typecheck` script to use the `-b` flag for TypeScript incremental builds in `cloudflare-d1`, `cloudflare`, `node-custom-server`, and `node-postgres`. [[1]](diffhunk://#diff-3736ed452ba204684295ed8b57b9bb7b6f320d20dce1558799c9f5e981e66e15L11-R11) [[2]](diffhunk://#diff-745e05f70b3fb5ac923f88cf3dda164ec17e32a10589e3b8d64f0d7ca006edf4L8-R8) [[3]](diffhunk://#diff-0c857afaab9a34ff1b92784f76f75e4fc41dbff6be43b08382a40258e2b6777eL8-R8) [[4]](diffhunk://#diff-07d1690a2738e54dc08328e7e28ab31eb87ee8a2fbb11488225ca0a163a73f69L10-R10)