### PR TITLE
Replace vite-node-miniflare with cloudflareDevProxy from @react-router/dev

### DIFF
--- a/cloudflare-d1/package.json
+++ b/cloudflare-d1/package.json
@@ -21,7 +21,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241112.0",
-    "@hiogawa/vite-node-miniflare": "0.1.1",
     "@react-router/dev": "*",
     "@types/node": "^20",
     "@types/react": "^19.0.1",

--- a/cloudflare-d1/vite.config.ts
+++ b/cloudflare-d1/vite.config.ts
@@ -1,4 +1,4 @@
-import { vitePluginViteNodeMiniflare } from "@hiogawa/vite-node-miniflare";
+import { cloudflareDevProxy } from "@react-router/dev/vite/cloudflare";
 import { reactRouter } from "@react-router/dev/vite";
 import autoprefixer from "autoprefixer";
 import tailwindcss from "tailwindcss";
@@ -18,35 +18,8 @@ export default defineConfig(({ isSsrBuild }) => ({
       plugins: [tailwindcss, autoprefixer],
     },
   },
-  ssr: {
-    target: "webworker",
-    noExternal: true,
-    external: ["node:async_hooks"],
-    resolve: {
-      conditions: ["workerd", "browser"],
-    },
-    optimizeDeps: {
-      include: [
-        "react",
-        "react/jsx-runtime",
-        "react/jsx-dev-runtime",
-        "react-dom",
-        "react-dom/server",
-        "react-router",
-      ],
-    },
-  },
   plugins: [
-    vitePluginViteNodeMiniflare({
-      entry: "./workers/app.ts",
-      miniflareOptions: (options) => {
-        options.compatibilityDate = "2024-11-18";
-        options.compatibilityFlags = ["nodejs_compat"];
-        options.d1Databases = { DB: "your-database-id" };
-        // match where wrangler applies migrations to
-        options.d1Persist = ".wrangler/state/v3/d1";
-      },
-    }),
+    cloudflareDevProxy(),
     reactRouter(),
     tsconfigPaths(),
   ],

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -17,7 +17,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241112.0",
-    "@hiogawa/vite-node-miniflare": "0.1.1",
     "@react-router/dev": "*",
     "@types/node": "^20",
     "@types/react": "^19.0.1",

--- a/cloudflare/vite.config.ts
+++ b/cloudflare/vite.config.ts
@@ -1,4 +1,4 @@
-import { vitePluginViteNodeMiniflare } from "@hiogawa/vite-node-miniflare";
+import { cloudflareDevProxy } from "@react-router/dev/vite/cloudflare";
 import { reactRouter } from "@react-router/dev/vite";
 import autoprefixer from "autoprefixer";
 import tailwindcss from "tailwindcss";
@@ -18,31 +18,8 @@ export default defineConfig(({ isSsrBuild }) => ({
       plugins: [tailwindcss, autoprefixer],
     },
   },
-  ssr: {
-    target: "webworker",
-    noExternal: true,
-    resolve: {
-      conditions: ["workerd", "browser"],
-    },
-    optimizeDeps: {
-      include: [
-        "react",
-        "react/jsx-runtime",
-        "react/jsx-dev-runtime",
-        "react-dom",
-        "react-dom/server",
-        "react-router",
-      ],
-    },
-  },
   plugins: [
-    vitePluginViteNodeMiniflare({
-      entry: "./workers/app.ts",
-      miniflareOptions: (options) => {
-        options.compatibilityDate = "2024-11-18";
-        options.compatibilityFlags = ["nodejs_compat"];
-      },
-    }),
+    cloudflareDevProxy(),
     reactRouter(),
     tsconfigPaths(),
   ],


### PR DESCRIPTION
## Issues with Cloudflare Templates
1. Duplicate configuration between `wrangler.toml` and `vite.config.ts` for dev mode
2. Complex `vite.config.ts` requiring manual CJS dependency configuration in `ssr.optimizeDeps.include` to work in dev mode
3. Dependency on [unmaintained](https://github.com/hi-ogawa/vite-plugins/issues/127#issuecomment-2157011007) `@hiogawa/vite-node-miniflare` for local dev mode
4. Prerendering issues ([#31](https://github.com/remix-run/react-router/issues/12758)) - to be fixed in PR remix-run/react-router-templates#45

## Solution
Using `cloudflareDevProxy` from `@react-router/dev`:
- Automatically pulls config from `wrangler.toml` for development
- CJS dependencies in dev mode work without manual configuration
- Automatically configures other `ssr` options or makes them unnecessary
- Both `cloudflare` and `cloudflare-d1` templates updated

@jacob-ebey: Any thoughts on why the templates weren't using `cloudflareDevProxy` initially?

Note: This supersedes remix-run/react-router-templates#6 (does this for `cloudflare` template and also adds `wrangler types` support). That should be separate since we need to decide on npm scripts and `.gitignore` handling.