### PR TITLE
fix: Cloudflare templates break when prerendering is enabled

### DIFF
--- a/cloudflare-d1/react-router.config.ts
+++ b/cloudflare-d1/react-router.config.ts
@@ -4,4 +4,5 @@ export default {
   // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: true,
+  serverBuildFile: "index.js",
 } satisfies Config;

--- a/cloudflare-d1/vite.config.ts
+++ b/cloudflare-d1/vite.config.ts
@@ -9,7 +9,10 @@ export default defineConfig(({ isSsrBuild }) => ({
   build: {
     rollupOptions: isSsrBuild
       ? {
-          input: "./workers/app.ts",
+          input: {
+            "index.js": "virtual:react-router/server-build",
+            "worker.js": "./workers/app.ts",
+          },
         }
       : undefined,
   },
@@ -48,6 +51,20 @@ export default defineConfig(({ isSsrBuild }) => ({
       },
     }),
     reactRouter(),
+    {
+      name: "react-router-cloudflare-workers",
+      config: () => ({
+        build: {
+          rollupOptions: isSsrBuild
+            ? {
+                output: {
+                  entryFileNames: "[name]",
+                },
+              }
+            : undefined,
+        },
+      }),
+    },
     tsconfigPaths(),
   ],
 }));

--- a/cloudflare-d1/wrangler.toml
+++ b/cloudflare-d1/wrangler.toml
@@ -2,7 +2,7 @@ workers_dev = true
 name = "my-worker"
 compatibility_date = "2024-11-18"
 compatibility_flags = ["nodejs_compat"]
-main = "./build/server/index.js"
+main = "./build/server/worker.js"
 assets = { directory = "./build/client/" }
 
 [[d1_databases]]

--- a/cloudflare/react-router.config.ts
+++ b/cloudflare/react-router.config.ts
@@ -4,4 +4,5 @@ export default {
   // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: true,
+  serverBuildFile: "index.js",
 } satisfies Config;

--- a/cloudflare/vite.config.ts
+++ b/cloudflare/vite.config.ts
@@ -9,7 +9,10 @@ export default defineConfig(({ isSsrBuild }) => ({
   build: {
     rollupOptions: isSsrBuild
       ? {
-          input: "./workers/app.ts",
+          input: {
+            "index.js": "virtual:react-router/server-build",
+            "worker.js": "./workers/app.ts",
+          },
         }
       : undefined,
   },
@@ -44,6 +47,20 @@ export default defineConfig(({ isSsrBuild }) => ({
       },
     }),
     reactRouter(),
+    {
+      name: "react-router-cloudflare-workers",
+      config: () => ({
+        build: {
+          rollupOptions: isSsrBuild
+            ? {
+                output: {
+                  entryFileNames: "[name]",
+                },
+              }
+            : undefined,
+        },
+      }),
+    },
     tsconfigPaths(),
   ],
 }));

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -1,5 +1,5 @@
 workers_dev = true
 name = "my-worker"
 compatibility_date = "2024-11-18"
-main = "./build/server/index.js"
+main = "./build/server/worker.js"
 assets = { directory = "./build/client/" }


### PR DESCRIPTION
## Issue Description
The Cloudflare templates fail when prerendering is enabled (#31) due to incompatibility between its custom entry point and React Router Vite plugin's prerendering assumptions.

### Technical Details
1. During prerendering, the plugin expects the entry point to be `virtual:react-router/server-build`
2. Cloudflare templates use a different entry point, causing the plugin to fail
3. The plugin sets `rollupOptions.entryFileNames` to `serverBuildFile` from `react-router.config.ts`, which prevents multiple entry points in `rollupOptions.input`

## Solution
Fix prerendering in the Cloudflare templates by:

1. **Workaround for Vite plugin limitation:** Forcing `entryFileNames` to be `[name]` to support multiple entry points
2. Specifying two entry points in `input`:
   - `index.js`: matches default `serverBuildFile` React Router configuration
   - `worker.js`: matched by updated `main = "./build/server/worker.js"` in `wrangler.toml`
3. Explicitly setting `index.js` as the `serverBuildFile` in `react-router.config.ts` for clarity and discoverability

Updated both `cloudflare` and `cloudflare-d1` templates.

## Proposed Long-term Fix
The React Router Vite plugin should be updated to support custom entry points for use cases like Cloudflare Workers.

### Suggested Implementation
```ts
{
  input: viteUserConfig.build?.rollupOptions?.input ?? {
    [ctx.reactRouterConfig.serverBuildFile]: serverBuildId,
  },
  output: {
    entryFileNames:
      typeof viteUserConfig.build?.rollupOptions?.input === "string"
        ? ctx.reactRouterConfig.serverBuildFile
        : "[name]",
    format: ctx.reactRouterConfig.serverModuleFormat,
  },
};
```

I considered leaving `entryFileNames` as the Rollup default `[name].js`, but this made it harder for the developer to match the `input` entries in `vite.config.ts` to the file names in `wrangler.toml` and `react-router.config.ts`. On the other hand, this changes Rollup's defaults and should be documented. Happy to change it back to Rollup's default and change `input` to `{index: ..., worker: ...}` if the maintainers have an opinion on this.

We should probably document this feature in general anyway though.

## Next Steps
- [ ] Open PR for official support for multiple entry points in React Router Vite plugin
- [ ] Remove the workaround of forcing `entryFileNames` to be `[name]` in the Cloudflare templates once the React Router Vite plugin is updated