### PR TITLE
Update entry.server.tsx to remove abortDelay prop on ServerRouter component

### DIFF
--- a/cloudflare/app/entry.server.tsx
+++ b/cloudflare/app/entry.server.tsx
@@ -3,8 +3,6 @@ import { ServerRouter } from "react-router";
 import { isbot } from "isbot";
 import { renderToReadableStream } from "react-dom/server";
 
-const ABORT_DELAY = 5_000;
-
 export default async function handleRequest(
   request: Request,
   responseStatusCode: number,
@@ -19,7 +17,6 @@ export default async function handleRequest(
     <ServerRouter
       context={routerContext}
       url={request.url}
-      abortDelay={ABORT_DELAY}
     />,
     {
       onError(error: unknown) {


### PR DESCRIPTION
Removed the abortDelay prop on the ServerRouter component. This prop should be removed since it's no longer supported by the component.

The error handling for the stream will still work as expected without this prop. The renderToReadableStream function handles timeouts internally.