### PR TITLE
Fix missing `extends` option on tsconfig

### DIFF
--- a/node-custom-server/package.json
+++ b/node-custom-server/package.json
@@ -5,7 +5,7 @@
     "build": "react-router build",
     "dev": "cross-env NODE_ENV=development node server.js",
     "start": "node server.js",
-    "typecheck": "react-router typegen && tsc"
+    "typecheck": "react-router typegen && tsc -b"
   },
   "dependencies": {
     "@react-router/express": "*",

--- a/node-custom-server/tsconfig.vite.json
+++ b/node-custom-server/tsconfig.vite.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.json",
   "include": [
     ".react-router/types/**/*",
     "app/**/*",


### PR DESCRIPTION
This was missing and was confusing me since the `verbatimModuleSyntax` was not working on the vite.tsconfig include files.
Thanks 🙏 