### PR TITLE
Set `node` as user in Dockerfile + some refactoring

### DIFF
--- a/default/Dockerfile
+++ b/default/Dockerfile
@@ -1,22 +1,17 @@
-FROM node:20-alpine AS development-dependencies-env
-COPY . /app
+FROM node:20-alpine AS base
+USER node
 WORKDIR /app
+COPY ./package.json package-lock.json /app/
+
+FROM base AS staging
 RUN npm ci
-
-FROM node:20-alpine AS production-dependencies-env
-COPY ./package.json package-lock.json /app/
-WORKDIR /app
-RUN npm ci --omit=dev
-
-FROM node:20-alpine AS build-env
 COPY . /app/
-COPY --from=development-dependencies-env /app/node_modules /app/node_modules
-WORKDIR /app
-RUN npm run build
+# Build app and prepare `node_modules` for production
+# This second install will remove the omitted deps automatically
+RUN npm run build \
+	&& npm ci --omit=dev
 
-FROM node:20-alpine
-COPY ./package.json package-lock.json /app/
-COPY --from=production-dependencies-env /app/node_modules /app/node_modules
-COPY --from=build-env /app/build /app/build
-WORKDIR /app
+FROM base
+COPY --from=staging /app/node_modules /app/node_modules
+COPY --from=staging /app/build /app/build
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
The most important part of these changes is deprivileging the user from [`root` to `node`](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#non-root-user) to mitigate escalation attacks.

The refactoring I've done is in the attempt of being a simple but solid Dockerfile for new and novice users by making it a little easier to understand with fewer repeated commands. Any resultant changes to built images should be trivial at best, which I've also checked with [Go Dive](https://github.com/wagoodman/dive) to confirm.

There are other Dockerfiles in this repo which could be updated, but I want to open up with this first to test the waters.