### PR TITLE
feat(cloudflare): switch from `@cloudflare/workers-types` to `wrangler types`

### DIFF
--- a/cloudflare-d1/package.json
+++ b/cloudflare-d1/package.json
@@ -10,7 +10,8 @@
     "db:migrate": "wrangler d1 migrations apply --local DB",
     "db:migrate-production": "dotenv -- drizzle-kit migrate",
     "cf-typegen": "wrangler types",
-    "typecheck": "npm run cf-typegen && react-router typegen && tsc -b"
+    "typecheck": "npm run cf-typegen && react-router typegen && tsc -b",
+    "postinstall": "npm run cf-typegen"
   },
   "dependencies": {
     "drizzle-orm": "~0.36.3",
@@ -21,7 +22,6 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.0.12",
-    "@cloudflare/workers-types": "^4.20250429.0",
     "@react-router/dev": "^7.5.3",
     "@tailwindcss/vite": "^4.1.4",
     "@types/node": "^20",

--- a/cloudflare-d1/tsconfig.cloudflare.json
+++ b/cloudflare-d1/tsconfig.cloudflare.json
@@ -13,7 +13,7 @@
     "composite": true,
     "strict": true,
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["@cloudflare/workers-types", "node", "vite/client"],
+    "types": [ "node", "vite/client"],
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -7,7 +7,8 @@
     "preview": "npm run build && vite preview",
     "deploy": "npm run build && wrangler deploy",
     "cf-typegen": "wrangler types",
-    "typecheck": "npm run cf-typegen && react-router typegen && tsc -b"
+    "typecheck": "npm run cf-typegen && react-router typegen && tsc -b",
+    "postinstall": "npm run cf-typegen"
   },
   "dependencies": {
     "isbot": "^5.1.27",
@@ -17,7 +18,6 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.0.12",
-    "@cloudflare/workers-types": "^4.20250429.0",
     "@react-router/dev": "^7.5.3",
     "@tailwindcss/vite": "^4.1.4",
     "@types/node": "^20",

--- a/cloudflare/tsconfig.cloudflare.json
+++ b/cloudflare/tsconfig.cloudflare.json
@@ -12,7 +12,7 @@
     "composite": true,
     "strict": true,
     "lib": ["DOM", "DOM.Iterable", "ES2022"],
-    "types": ["@cloudflare/workers-types", "vite/client"],
+    "types": ["vite/client"],
     "target": "ES2022",
     "module": "ES2022",
     "moduleResolution": "bundler",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.0.12
         version: 1.0.12(rollup@4.35.0)(vite@6.3.3(@types/node@20.17.6)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.2)(yaml@2.6.1))(workerd@1.20250424.0)(wrangler@4.13.2(@cloudflare/workers-types@4.20250429.0))
-      '@cloudflare/workers-types':
-        specifier: ^4.20250429.0
-        version: 4.20250429.0
       '@react-router/dev':
         specifier: ^7.5.3
         version: 7.5.3(@react-router/serve@7.5.3(react-router@7.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3))(@types/node@20.17.6)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@7.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tsx@4.19.2)(typescript@5.8.3)(vite@6.3.3(@types/node@20.17.6)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.2)(yaml@2.6.1))(wrangler@4.13.2(@cloudflare/workers-types@4.20250429.0))(yaml@2.6.1)
@@ -103,9 +100,6 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.0.12
         version: 1.0.12(rollup@4.35.0)(vite@6.3.3(@types/node@20.17.6)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.2)(yaml@2.6.1))(workerd@1.20250424.0)(wrangler@4.13.2(@cloudflare/workers-types@4.20250429.0))
-      '@cloudflare/workers-types':
-        specifier: ^4.20250429.0
-        version: 4.20250429.0
       '@react-router/dev':
         specifier: ^7.5.3
         version: 7.5.3(@react-router/serve@7.5.3(react-router@7.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3))(@types/node@20.17.6)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.29.2)(react-router@7.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tsx@4.19.2)(typescript@5.8.3)(vite@6.3.3(@types/node@20.17.6)(jiti@2.4.2)(lightningcss@1.29.2)(tsx@4.19.2)(yaml@2.6.1))(wrangler@4.13.2(@cloudflare/workers-types@4.20250429.0))(yaml@2.6.1)
@@ -6899,7 +6893,8 @@ snapshots:
   '@cloudflare/workerd-windows-64@1.20250424.0':
     optional: true
 
-  '@cloudflare/workers-types@4.20250429.0': {}
+  '@cloudflare/workers-types@4.20250429.0':
+    optional: true
 
   '@colors/colors@1.6.0': {}
 


### PR DESCRIPTION
As of Wrangler v4, Cloudflare recommends using [`wrangler types`](https://developers.cloudflare.com/workers/wrangler/commands/#types) to generate Cloudflare runtime types based on compat date + flags, instead of the`@cloudflare/workers-types` package. This PR updates the Cloudflare templates accordingly.



