### PR TITLE
fix(rsc-vite): add `import.meta.hot.accept` to rsc entry

### DIFF
--- a/unstable_rsc-vite/src/entry.rsc.tsx
+++ b/unstable_rsc-vite/src/entry.rsc.tsx
@@ -40,3 +40,7 @@ export default async function handler(request: Request) {
 
   return ssr.generateHTML(request, fetchServer);
 }
+
+if (import.meta.hot) {
+  import.meta.hot.accept();
+}


### PR DESCRIPTION
This PR adds `import.meta.hot.accept()` to Vite rsc entry. Without this, any server file change invalidates server module graph entirely on vite module runner. You can find more details in the PR where I changed my templates https://github.com/hi-ogawa/vite-plugins/pull/1114

Vite's documentation doesn't mention this behavior yet, but I plan to suggest changes there as well later.
