### PR TITLE
Avoid vercel preset locally to prevent incorrect server index path

### DIFF
--- a/vercel/react-router.config.ts
+++ b/vercel/react-router.config.ts
@@ -5,5 +5,5 @@ export default {
   // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: true,
-  presets: [vercelPreset()],
+  presets: process.env.VERCEL ? [vercelPreset()] : undefined,
 } satisfies Config;


### PR DESCRIPTION
This MR ensures the `vercelPreset` is only applied when building on Vercel. Applying it unconditionally was causing issues with the local build because the preset modifies the server index path.

Specifically, it didn’t align with the local start command:

```json
"start": "react-router-serve ./build/server/index.js"
```

By conditionally including the preset only when `process.env.VERCEL` is set, we preserve correct behavior both locally and in the Vercel deployment environment.