### PR TITLE
fix(rsc): pass temporary references options on rsc render

### DIFF
--- a/unstable_rsc-parcel/src/entry.rsc.tsx
+++ b/unstable_rsc-parcel/src/entry.rsc.tsx
@@ -29,8 +29,8 @@ function fetchServer(request: Request) {
     // The app routes.
     routes: routes(),
     // Encode the match with the React Server implementation.
-    generateResponse(match) {
-      return new Response(renderToReadableStream(match.payload), {
+    generateResponse(match, options) {
+      return new Response(renderToReadableStream(match.payload, options), {
         status: match.statusCode,
         headers: match.headers,
       });

--- a/unstable_rsc-vite/src/entry.rsc.tsx
+++ b/unstable_rsc-vite/src/entry.rsc.tsx
@@ -23,8 +23,8 @@ function fetchServer(request: Request) {
     // The app routes.
     routes: routes(),
     // Encode the match with the React Server implementation.
-    generateResponse(match) {
-      return new Response(renderToReadableStream(match.payload), {
+    generateResponse(match, options) {
+      return new Response(renderToReadableStream(match.payload, options), {
         status: match.statusCode,
         headers: match.headers,
       });


### PR DESCRIPTION
Temporary references aren't working without this option. This aligns with playground code on main repo https://github.com/remix-run/react-router/blob/8b7f38911bd9e9dce78b780ca15bdf9ef88b6f28/playground/rsc-vite/src/entry.rsc.tsx#L21-L22