### PR TITLE
fix: font flickering and preload warnings

### DIFF
--- a/cloudflare-d1/app/root.tsx
+++ b/cloudflare-d1/app/root.tsx
@@ -18,7 +18,9 @@ export const links: Route.LinksFunction = () => [
     crossOrigin: "anonymous",
   },
   {
-    rel: "stylesheet",
+    as: "style",
+    rel: "stylesheet preload prefetch",
+    crossOrigin: "anonymous",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];

--- a/cloudflare/app/root.tsx
+++ b/cloudflare/app/root.tsx
@@ -18,7 +18,9 @@ export const links: Route.LinksFunction = () => [
     crossOrigin: "anonymous",
   },
   {
-    rel: "stylesheet",
+    as: "style",
+    rel: "stylesheet preload prefetch",
+    crossOrigin: "anonymous",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];

--- a/default/app/root.tsx
+++ b/default/app/root.tsx
@@ -18,7 +18,9 @@ export const links: Route.LinksFunction = () => [
     crossOrigin: "anonymous",
   },
   {
-    rel: "stylesheet",
+    as: "style",
+    rel: "stylesheet preload prefetch",
+    crossOrigin: "anonymous",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];

--- a/deno/app/root.tsx
+++ b/deno/app/root.tsx
@@ -18,7 +18,9 @@ export const links: Route.LinksFunction = () => [
     crossOrigin: "anonymous",
   },
   {
-    rel: "stylesheet",
+    as: "style",
+    rel: "stylesheet preload prefetch",
+    crossOrigin: "anonymous",
     href:
       "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },

--- a/javascript/app/root.jsx
+++ b/javascript/app/root.jsx
@@ -17,7 +17,9 @@ export const links = () => [
     crossOrigin: "anonymous",
   },
   {
-    rel: "stylesheet",
+    as: "style",
+    rel: "stylesheet preload prefetch",
+    crossOrigin: "anonymous",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];

--- a/netlify/app/root.tsx
+++ b/netlify/app/root.tsx
@@ -18,7 +18,9 @@ export const links: Route.LinksFunction = () => [
     crossOrigin: "anonymous",
   },
   {
-    rel: "stylesheet",
+    as: "style",
+    rel: "stylesheet preload prefetch",
+    crossOrigin: "anonymous",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];

--- a/node-custom-server/app/root.tsx
+++ b/node-custom-server/app/root.tsx
@@ -18,7 +18,9 @@ export const links: Route.LinksFunction = () => [
     crossOrigin: "anonymous",
   },
   {
-    rel: "stylesheet",
+    as: "style",
+    rel: "stylesheet preload prefetch",
+    crossOrigin: "anonymous",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];

--- a/node-postgres/app/root.tsx
+++ b/node-postgres/app/root.tsx
@@ -18,7 +18,9 @@ export const links: Route.LinksFunction = () => [
     crossOrigin: "anonymous",
   },
   {
-    rel: "stylesheet",
+    as: "style",
+    rel: "stylesheet preload prefetch",
+    crossOrigin: "anonymous",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];

--- a/vercel/app/root.tsx
+++ b/vercel/app/root.tsx
@@ -18,7 +18,9 @@ export const links: Route.LinksFunction = () => [
     crossOrigin: "anonymous",
   },
   {
-    rel: "stylesheet",
+    as: "style",
+    rel: "stylesheet preload prefetch",
+    crossOrigin: "anonymous",
     href: "https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap",
   },
 ];


### PR DESCRIPTION
This PR addresses the following UI issues:

- Fixes flash of unstyled text while fonts are loading by preloading the font stylesheets in all templates
- By setting the proper as, rel and crossorigin attributes, it prevents the browser warning: `The resource https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.`