### PR TITLE
fix: vercel template start script is broken

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -643,6 +643,9 @@ importers:
       '@react-router/dev':
         specifier: ^7.7.1
         version: 7.7.1(@react-router/serve@7.7.1(react-router@7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3))(@types/node@20.17.6)(babel-plugin-macros@3.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(react-router@7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(tsx@4.19.2)(typescript@5.8.3)(vite@6.3.3(@types/node@20.17.6)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.2)(yaml@2.6.1))(wrangler@4.22.0(@cloudflare/workers-types@4.20250429.0))(yaml@2.6.1)
+      '@react-router/serve':
+        specifier: ^7.7.1
+        version: 7.7.1(react-router@7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
       '@tailwindcss/vite':
         specifier: ^4.1.4
         version: 4.1.4(vite@6.3.3(@types/node@20.17.6)(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.19.2)(yaml@2.6.1))

--- a/vercel/package.json
+++ b/vercel/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "react-router build",
     "dev": "react-router dev",
-    "start": "react-router-serve ./build/server/index.js",
+    "start": "node scripts/start-server.js",
     "typecheck": "react-router typegen && tsc"
   },
   "dependencies": {
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@react-router/dev": "^7.7.1",
+    "@react-router/serve": "^7.7.1",
     "@tailwindcss/vite": "^4.1.4",
     "@types/node": "^20",
     "@types/react": "^19.1.2",

--- a/vercel/scripts/start-server.js
+++ b/vercel/scripts/start-server.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { readdir, stat } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+async function findServerBuildDir() {
+  const buildServerPath = join(__dirname, '..', 'build', 'server')
+
+  try {
+    // Check if the build/server directory exists
+    await stat(buildServerPath)
+  } catch (error) {
+    console.error('Error: build/server directory not found. Please run "pnpm build" first.')
+    process.exit(1)
+  }
+
+  try {
+    const entries = await readdir(buildServerPath)
+
+    // Find the first folder that starts with 'nodejs_'
+    const nodejsFolder = entries.find((entry) => entry.startsWith('nodejs_'))
+
+    if (!nodejsFolder) {
+      console.error('Error: No nodejs_* folder found in build/server. Please run "pnpm build" first.')
+      process.exit(1)
+    }
+
+    return join(buildServerPath, nodejsFolder)
+  } catch (error) {
+    console.error('Error reading build/server directory:', error.message)
+    process.exit(1)
+  }
+}
+
+async function startServer() {
+  try {
+    const serverBuildDir = await findServerBuildDir()
+    const indexPath = join(serverBuildDir, 'index.js')
+
+    console.log(`Starting server from: ${indexPath}`)
+
+    // Spawn the react-router-serve process
+    const child = spawn('react-router-serve', [indexPath], {
+      stdio: 'inherit',
+      env: { ...process.env },
+    })
+
+    child.on('error', (error) => {
+      console.error('Failed to start server:', error.message)
+      process.exit(1)
+    })
+
+    child.on('exit', (code) => {
+      process.exit(code)
+    })
+  } catch (error) {
+    console.error('Error starting server:', error.message)
+    process.exit(1)
+  }
+}
+
+startServer()


### PR DESCRIPTION
Since `@vercel/react-router` builds the server in a randomly generated directory based on a build ID, we need to find it first in order to be able to serve it.

This PR implements a simple JS script to find the output dir and run `react-router-serve`.