### PR TITLE
fix(cloudflare): update stabilized future flags for v7.10.0

### DIFF
--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -14,7 +14,7 @@
     "isbot": "^5.1.31",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-router": "^7.9.2"
+    "react-router": "^7.10.0"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.13.7",

--- a/cloudflare/package.json
+++ b/cloudflare/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.13.7",
-    "@react-router/dev": "^7.9.2",
+    "@react-router/dev": "^7.10.0",
     "@tailwindcss/vite": "^4.1.13",
     "@types/node": "^22",
     "@types/react": "^19.1.15",

--- a/cloudflare/react-router.config.ts
+++ b/cloudflare/react-router.config.ts
@@ -3,6 +3,6 @@ import type { Config } from "@react-router/dev/config";
 export default {
   ssr: true,
   future: {
-    unstable_viteEnvironmentApi: true,
+    v8_viteEnvironmentApi: true,
   },
 } satisfies Config;


### PR DESCRIPTION
React Router v7.10.0 stabilized unstable_viteEnvironmentApi to v8_viteEnvironmentApi.

Since the Cloudflare template uses ^7.9.x in package.json, new projects automatically install 7.10.0, causing an immediate crash on npm run dev.

This PR updates the config flag and bumps the minimum version to ^7.10.0 to resolve the conflict.